### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2.5.1

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2.5.1

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2.5.1


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
